### PR TITLE
Fix names with special characters

### DIFF
--- a/src/main/java/io/kokuwa/edge/esh/constants/maven/plugin/GenerateConstantsMojo.java
+++ b/src/main/java/io/kokuwa/edge/esh/constants/maven/plugin/GenerateConstantsMojo.java
@@ -5,10 +5,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -96,7 +93,20 @@ public class GenerateConstantsMojo extends AbstractMojo {
 		constants.putAll(toConstants(channelGroupTypeIDs, "CHANNEL_GROUP_TYPE_ID_"));
 
 		// Generate code from template
-		String classResult = createClassFromTemplate(bindingId, constants, bridgeTypeIDs, thingTypeIDs, channelUIDs);
+		String classResult = createClassFromTemplate(
+				bindingId,
+				constants,
+				bridgeTypeIDs
+						.stream()
+						.map(id->id.replaceAll("\\W", "_"))
+						// we must preserve the order, otherwise the unit test fails
+						.collect(LinkedHashSet::new, HashSet::add, AbstractCollection::addAll),
+				thingTypeIDs
+						.stream()
+						.map(id->id.replaceAll("\\W", "_"))
+						// we must preserve the order, otherwise the unit test fails
+						.collect(LinkedHashSet::new, HashSet::add, AbstractCollection::addAll),
+				channelUIDs);
 
 		// Write output file
 		writeFile(Path.of(this.outputDirectory, this.className + ".java"), classResult);
@@ -196,7 +206,7 @@ public class GenerateConstantsMojo extends AbstractMojo {
 	private Map<String, String> toConstants(Set<String> values, String prefix) {
 		Map<String, String> result = new LinkedHashMap<>();
 		for (String value : values) {
-			result.put(prefix + value.toUpperCase(), value);
+			result.put(prefix + value.toUpperCase().replaceAll("\\W", "_"), value);
 		}
 		return result;
 	}

--- a/src/test/resources/ESH-INF/thing/thing-types.xml
+++ b/src/test/resources/ESH-INF/thing/thing-types.xml
@@ -72,6 +72,12 @@
         </config-description>
     </thing-type>
 
+    <!-- thing definition with a dash in its name -->
+    <thing-type id="ego-tcp">
+        <label>EGO</label>
+        <description>EGO</description>
+    </thing-type>
+
     <!-- channel definitions for all WMBus devices -->
     <channel-type id="room_temperature">
 		<item-type>Number</item-type>

--- a/src/test/resources/expected.java
+++ b/src/test/resources/expected.java
@@ -31,6 +31,7 @@ public final class Constants {
 	public static final String THING_TYPE_ID_TECHEM_WMZ43 = "techem_wmz43";
 	public static final String THING_TYPE_ID_METER = "meter";
 	public static final String THING_TYPE_ID_ENCRYPTED_METER = "encrypted_meter";
+	public static final String THING_TYPE_ID_EGO_TCP = "ego-tcp";
 	public static final String BRIDGE_TYPE_ID_WMBUSBRIDGE = "wmbusbridge";
 	public static final String BRIDGE_TYPE_ID_WMBUSVIRTUALBRIDGE = "wmbusvirtualbridge";
 	public static final String CHANNEL_ID_LAST_FRAME = "last_frame";
@@ -191,6 +192,7 @@ public final class Constants {
 	public static final ThingTypeUID TECHEM_WMZ43_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID_TECHEM_WMZ43);
 	public static final ThingTypeUID METER_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID_METER);
 	public static final ThingTypeUID ENCRYPTED_METER_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID_ENCRYPTED_METER);
+	public static final ThingTypeUID EGO_TCP_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID_EGO_TCP);
 
 	// ChannelUIDs for itron_smoke_detector
 	public static final ChannelUID ITRON_SMOKE_DETECTOR_CURRENT_DATE_UID = new ChannelUID(ITRON_SMOKE_DETECTOR_THING_TYPE_UID, CHANNEL_ID_CURRENT_DATE);
@@ -349,5 +351,7 @@ public final class Constants {
 	// ChannelUIDs for meter
 
 	// ChannelUIDs for encrypted_meter
+
+	// ChannelUIDs for ego-tcp
 
 }


### PR DESCRIPTION
Apparently some of the IDs may contain special characters like `-`,
which have led to invalid Java code. This commit replaces all special
chars with `_` to ensure valid Java identifiers.