### PR TITLE
Skip standard properties from org.eclipse.smarthome.core.thing.Thing

### DIFF
--- a/src/test/resources/ESH-INF/thing/thing-types.xml
+++ b/src/test/resources/ESH-INF/thing/thing-types.xml
@@ -32,6 +32,17 @@
                 <unitLabel>minutes</unitLabel>
             </parameter>
         </config-description>
+
+        <!-- standard properties from org.eclipse.smarthome.core.thing.Thing, should be skipped -->
+        <properties>
+            <property name="vendor">N/A</property>
+            <property name="modelId">N/A</property>
+            <property name="serialNumber">N/A</property>
+            <property name="hardwareVersion">N/A</property>
+            <property name="firmwareVersion">N/A</property>
+            <property name="macAddress">N/A</property>
+        </properties>
+
     </thing-type>
 
     <!-- thing definition for encrypted, but still standard meter -->

--- a/src/test/resources/expected.java
+++ b/src/test/resources/expected.java
@@ -16,8 +16,6 @@ public final class Constants {
 	public static final String BINDING_ID = "wmbus";
 
 	// Constants
-	public static final String PROPERTY_VENDOR = "vendor";
-	public static final String PROPERTY_MODELID = "modelId";
 	public static final String PROPERTY_SERIAL = "serial";
 	public static final String THING_TYPE_ID_ITRON_SMOKE_DETECTOR = "itron_smoke_detector";
 	public static final String THING_TYPE_ID_TECHEM_HKV45 = "techem_hkv45";


### PR DESCRIPTION
The `org.eclipse.smarthome.core.thing.Thing` predefines some standard property names, so they are not needed in the generated constants. On the other hand, standard values for properties maybe defined in the XML.

This commit introduces these constants as a set so that the generator can skip them.

Signed-off-by: Ringo Frischmann <ringo.frischmann@kiwigrid.com>